### PR TITLE
Prevent library from hanging in failure case

### DIFF
--- a/lib/parse-canonical-url.js
+++ b/lib/parse-canonical-url.js
@@ -35,6 +35,8 @@ exports.canonical = function(url) {
                     } else {
                         reject(new Error(error));
                     }
+                } else {
+                    reject(new Error('bad status code'));
                 }
             });
         } else {


### PR DESCRIPTION
When passed a valid web uri that responds with a bad status code, this library was just hanging. The library should reject so that the user can handle this case.